### PR TITLE
Added AKS kubeconfig download functionality

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Flags:
 Use "kcmanager [command] --help" for more information about a command.
 ```
 
-### _kcmanager add_ options
+### __kcmanager add__
 
 By default, if not specified with a flag the bahaviour of kcmanager is next:
 
@@ -53,7 +53,8 @@ Usage:
   kcmanager add [command]
 
 Available Commands:
-  rancher     adding kubeconfig downloaded from a specific rancher installation
+  aks         adds kubeconfig downloaded from Azure
+  rancher     adds kubeconfig downloaded from a specific rancher installation
 
 Flags:
   -h, --help   help for add
@@ -64,18 +65,14 @@ Global Flags:
 Use "kcmanager add [command] --help" for more information about a command.
 ```
 
-Currently implemented flags
+Currently implemented subcommands for __add__ 
 
-- _rancher_
+#### __rancher__
 
-This flag requires additional enviroenmtn variable RANCHER_TOKEN to be set. This allows to download a kubeconfig for a specific cluster listed in your rancher installation and then add it to your current configuration. Example usage:
+This subcommand requires additional environment variable RANCHER_TOKEN to be set. 
+This allows to download a kubeconfig for a specific cluster listed in your rancher installation and then add it to your current configuration. Example usage:
 
 ```bash
-export RANCHER_TOKEN=token-xxxxx:xxxxxxxxxxxxxxxxxxxxxxxxx
-
-kcmanager add rancher
-adding kubeconfig downloaded from a specific rancher installation
-
 Usage:
   kcmanager add rancher --url=[rancher url] --token=[rancher token|| or the env variable] [flags]
 
@@ -84,6 +81,28 @@ Flags:
   -h, --help             help for rancher
   -t, --token string     token to a Rancher
   -u, --url string       URL to a Rancher
+
+Global Flags:
+  -v, --verbose   verbose output
+```
+
+#### __aks_
+
+This subcommand requires additional Azure environment variables to be set:
+* SUBSCRIPTION_ID - subscription ID where your cluster is located
+* TENANT_ID - Azure tenant ID
+* CLIENT_ID - client ID for service-principal
+* CLIENT_SECRET secret for the service principal
+
+```bash
+Usage:
+  kcmanager add aks --url=[rancher url] --token=[rancher token] [flags]
+
+Flags:
+  -a, --admin                   Download a user/admin credentials
+  -c, --cluster string          Name of a cluster
+  -h, --help                    help for azure
+  -r, --resource-group string   Resource Group in which cluster is located
 
 Global Flags:
   -v, --verbose   verbose output

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.16
 
 require (
 	facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
+	github.com/ghodss/yaml v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
+	github.com/stretchr/testify v1.7.0
 	k8s.io/client-go v0.22.2
 )

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/internal/azureAKSClient/azureAKSConfig.go
+++ b/internal/azureAKSClient/azureAKSConfig.go
@@ -1,0 +1,136 @@
+package azureAKSClient
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	yaml "github.com/ghodss/yaml"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	// "gopkg.in/yaml.v2"
+)
+
+var (
+	tenantID       string
+	subscriptionID string
+	clientID       string
+	clientSecret   string
+	resource       string
+	resourceURL    string
+)
+
+const (
+	apiVersion = "2021-05-01"
+)
+
+func IfAdmin(cond bool) string {
+	if cond {
+		return fmt.Sprintf("listCluster%sCredential", "Admin")
+	}
+	return fmt.Sprintf("listCluster%sCredential", "User")
+}
+
+func GetConfig(rg string, name string, admin bool) (*api.Config, error) {
+	token := GetToken()
+	tokenString := fmt.Sprintf("%s %s", token.Type, token.Token)
+	URL := fmt.Sprintf("%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s/%s?api-version=%s", resource, subscriptionID, rg, name, IfAdmin(admin), apiVersion)
+	req, err := http.NewRequest("POST", URL, nil)
+	RespError(err)
+
+	// add authorization header to the req
+	req.Header.Add("Authorization", tokenString)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send req using http Client
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	RespError(err)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	RespError(err)
+	var kubeconfigs AzureAKSCredentials
+	err = json.Unmarshal([]byte(body), &kubeconfigs)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	configEncoded, _ := base64.StdEncoding.DecodeString(kubeconfigs.Kubeconfigs[0].Value)
+	config, err := yaml.YAMLToJSON(configEncoded)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	cfg, err := clientcmd.Load([]byte(config))
+	RespError(err)
+
+	return cfg, nil
+}
+
+func GetToken() Token {
+	tenantID = GetOSVar("TENANT_ID")
+	clientID = GetOSVar("CLIENT_ID")
+	clientSecret = GetOSVar("CLIENT_SECRET")
+	subscriptionID = GetOSVar("SUBSCRIPTION_ID")
+	resourceURL = fmt.Sprintf("%s/oauth2/token", tenantID)
+	resource = "https://management.azure.com"
+	URL := "https://login.microsoftonline.com/"
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("resource", resource)
+	data.Set("client_id", clientID)
+	data.Set("client_secret", clientSecret)
+
+	u, _ := url.ParseRequestURI(URL)
+	u.Path = resourceURL
+	u.RawQuery = data.Encode()
+	urlStr := u.String()
+
+	client := &http.Client{}
+	r, _ := http.NewRequest(http.MethodPost, urlStr, strings.NewReader(data.Encode()))
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
+
+	resp, err := client.Do(r)
+	RespError(err)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	RespError(err)
+	fmt.Println(string(body))
+	var authData AuthData
+	err = json.Unmarshal([]byte(body), &authData)
+	if err != nil {
+		fmt.Println(err)
+	}
+	authToken := Token{
+		Type:  authData.TokenType,
+		Token: authData.AccessToken,
+	}
+	return authToken
+}
+
+func GetOSVar(envVar string) string {
+	value, present := os.LookupEnv(envVar)
+	if !present {
+		err := fmt.Sprintf("environment variable %s not set", envVar)
+		RespError(errors.New(err))
+		return ""
+	}
+	return value
+}
+
+func RespError(err error) {
+	if err != nil {
+		fmt.Printf("there was an error during the call execution: %s\n", err)
+	}
+}

--- a/internal/azureAKSClient/azureAKSConfig_test.go
+++ b/internal/azureAKSClient/azureAKSConfig_test.go
@@ -1,0 +1,71 @@
+package azureAKSClient_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/kalgurn/kubeconfig-manager/internal/azureAKSClient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIfAdminYes(t *testing.T) {
+	assert := assert.New(t)
+	admin := "listClusterAdminCredential"
+	ifAdmin := azureAKSClient.IfAdmin(true)
+	assert.Equal(admin, ifAdmin, "should be equal")
+}
+func TestIfAdminNo(t *testing.T) {
+	assert := assert.New(t)
+	admin := "listClusterUserCredential"
+	ifAdmin := azureAKSClient.IfAdmin(false)
+	assert.Equal(admin, ifAdmin, "should be equal")
+}
+
+// I have no idea how to mock this calls at the moment :(
+//func TestGetConfig(t *testing.T) {}
+
+// func TestGetToken(t *testing.T) {
+// 	os.Setenv("TENANT_ID", "tenant")
+// 	os.Setenv("SUBSCRIPTION_ID", "subscription")
+// 	os.Setenv("CLIENT_ID", "client")
+// 	os.Setenv("CLIENT_SECRET", "secret")
+
+// 	azureTokenResp := `{
+// 		"token_type": "Bearer",
+// 		"expires_in": "11",
+// 		"ext_expires_in": "11",
+// 		"expires_on": "11",
+// 		"not_before": "11",
+// 		"resource": "https://management.azure.com",
+// 		"access_token": "Token"
+// 	}`
+
+// 	azureValidToken := azureAKSClient.Token{
+// 		Type:  "Bearer",
+// 		Token: "Token",
+// 	}
+
+// 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		w.Write([]byte(azureTokenResp))
+// 	}))
+// 	defer ts.Close()
+
+// 	tokenID := azureAKSClient.GetToken()
+// 	if tokenID != azureValidToken {
+// 		t.Errorf("Get Token failed - expected %v, got %v", azureValidToken, tokenID)
+// 	}
+// }
+func TestGetOSVar(t *testing.T) {
+	assert := assert.New(t)
+	os.Setenv("TESTVAR", "TESTVALUE")
+
+	testvalue := "TESTVALUE"
+	testvar := azureAKSClient.GetOSVar("TESTVAR")
+	assert.Equal(testvalue, testvar, "should be equal")
+
+}
+func TestRespErr(t *testing.T) {
+	err := errors.New("test")
+	azureAKSClient.RespError(err)
+}

--- a/internal/azureAKSClient/types.go
+++ b/internal/azureAKSClient/types.go
@@ -1,0 +1,60 @@
+package azureAKSClient
+
+type AuthData struct {
+	TokenType    string `json:"token_type"`
+	ExpiresIn    string `json:"expires_in"`
+	ExtExpiresIn string `json:"ext_expires_in"`
+	ExpiresOn    string `json:"expires_on"`
+	NotBefore    string `json:"not_before"`
+	Resource     string `json:"resource"`
+	AccessToken  string `json:"access_token"`
+}
+
+type AzureAKSCredentials struct {
+	Kubeconfigs []Kubeconfig `json:"kubeconfigs"`
+}
+
+// type AzureAKSConfigYaml struct {
+// 	ApiVersion     string                                `yaml:"apiVersion"`
+// 	Clusters       map[string]AzureAKSConfigClustersYaml `yaml:"clusters"`
+// 	Contexts       map[string]AzureAKSConfigContextsYaml `yaml:"contexts"`
+// 	CurrentContext string                                `yaml:"current-context"`
+// 	Kind           string                                `yaml:"kind"`
+// 	Preferences    map[string]string                     `yaml:"preferences"`
+// 	Users          map[string]AzureAKSConfigUsursYaml    `yaml:"users"`
+// }
+
+// type AzureAKSConfigClustersYaml struct {
+// 	Cluster []AzureAKSConfigClusterYaml `yaml:"cluster"`
+// 	Name    string                      `yaml:"name"`
+// }
+// type AzureAKSConfigClusterYaml struct {
+// 	CertificateAuthorityData string `yaml:"certificate-authority-data"`
+// 	Server                   string `yaml:"server"`
+// }
+// type AzureAKSConfigContextsYaml struct {
+// 	Context []AzureAKSConfigContextYaml `yaml:"context"`
+// 	Name    string                      `yaml:"name"`
+// }
+// type AzureAKSConfigContextYaml struct {
+// 	CLuster string `yaml:"cluster"`
+// 	User    string `yaml:"user"`
+// }
+// type AzureAKSConfigUsursYaml struct {
+// 	User []AzureAKSConfigUserYaml `yaml:"user"`
+// 	Name string                   `yaml:"name"`
+// }
+// type AzureAKSConfigUserYaml struct {
+// 	ClientCertificateData string `yaml:"client-certificate-data"`
+// 	ClientKeyData         string `yaml:"client-key-data"`
+// 	Token                 string `yaml:"token"`
+// }
+
+type Kubeconfig struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+type Token struct {
+	Token string
+	Type  string
+}

--- a/internal/cmd/addAKS.go
+++ b/internal/cmd/addAKS.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kalgurn/kubeconfig-manager/internal/azureAKSClient"
+	"github.com/kalgurn/kubeconfig-manager/internal/kubeconfig"
+	log "github.com/kalgurn/kubeconfig-manager/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	AzureRG        string
+	AzureCluster   string
+	AzureAdminCred bool
+)
+
+//CodeSmell variables to make Sonar happy
+const (
+	AzureRGString        = "resource-group"
+	AzureClusterString   = "cluster"
+	AzureAdminCredString = "admin"
+)
+
+func init() {
+
+	addAKSCmd.Flags().StringVarP(&AzureRG, AzureRGString, "r", "", "Resource Group in which cluster is located")
+	addAKSCmd.Flags().StringVarP(&AzureCluster, AzureClusterString, "c", "", "Name of a cluster")
+	addAKSCmd.Flags().BoolVarP(&AzureAdminCred, AzureAdminCredString, "a", false, "Download a user or admin credentials")
+	addAKSCmd.MarkFlagRequired(AzureRGString)
+	addAKSCmd.MarkFlagRequired(AzureClusterString)
+	addCmd.AddCommand(addAKSCmd)
+}
+
+func AddAKSComposer(cmd *cobra.Command, args []string) error {
+	AzureRG, _ = cmd.Flags().GetString(AzureRGString)
+	AzureCluster, _ = cmd.Flags().GetString(AzureClusterString)
+	AzureAdminCred, _ = cmd.Flags().GetBool(AzureAdminCredString)
+
+	err := AddAKS(AzureRG, AzureCluster, AzureAdminCred)
+
+	return err
+}
+func AddAKS(rg string, name string, admin bool) error {
+	kubeconfigPath, err := kubeconfig.GetConfigPath()
+	if err != nil {
+		return fmt.Errorf("%s", err)
+	}
+	defaultCfg := kubeconfig.Load(kubeconfigPath)
+	logger = log.NewLogger(Verbose)
+	logger.Debug("downloading kubeconfig for a cluster ", AzureCluster, " from ", AzureRG)
+	azureCfg, err := azureAKSClient.GetConfig(rg, name, admin)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	logger.Debug("merging config with ", kubeconfigPath)
+	kubeconfig.Merge(azureCfg, defaultCfg)
+	logger.Debug("saving config to ", kubeconfigPath)
+	kubeconfig.Save(kubeconfigPath, defaultCfg)
+	logger.Info("config saved")
+
+	return nil
+}
+
+var addAKSCmd = &cobra.Command{
+	Use:   "aks --resource-group=[Azure RG name] --cluster=[cluster name] --admin[true if set]",
+	Short: "adds kubeconfig downloaded from Azure",
+	Long:  "adds kubeconfig downloaded from Azure",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return AddAKSComposer(cmd, args)
+	},
+}

--- a/internal/cmd/addAKS_test.go
+++ b/internal/cmd/addAKS_test.go
@@ -1,0 +1,43 @@
+package cmd_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kalgurn/kubeconfig-manager/internal/cmd"
+	"github.com/kalgurn/kubeconfig-manager/internal/kubeconfig"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestAddAKS(t *testing.T) {
+	cfg := api.NewConfig()
+	cfg.Contexts["ctx1-test"] = api.NewContext()
+	cfg.Clusters["ctx1-test"] = api.NewCluster()
+	cfg.AuthInfos["ctx1-test"] = api.NewAuthInfo()
+	cfg.CurrentContext = "ctx1-test"
+	kubeconfig.Export("ctx1-test", cfg)
+	os.Setenv("KUBECONFIG", "ctx1-test.yaml")
+
+	var addCmd = &cobra.Command{
+		Use:   "add",
+		Short: "Desc",
+		Run:   emptyRun,
+	}
+	var addAKSCmd = &cobra.Command{
+		Use:   "aks",
+		Short: "Desc",
+		RunE: func(command *cobra.Command, args []string) error {
+			return cmd.AddAKSComposer(command, args)
+		},
+	}
+	var (
+		AzureRG        string
+		AzureCluster   string
+		AzureAdminCred bool
+	)
+	addCmd.AddCommand(addAKSCmd)
+	addAKSCmd.Flags().StringVarP(&AzureRG, "resource-group", "r", "", "Resource Group in which cluster is located")
+	addAKSCmd.Flags().StringVarP(&AzureCluster, "cluster", "c", "", "Name of a cluster")
+	addAKSCmd.Flags().BoolVarP(&AzureAdminCred, "admin", "a", false, "Download a user or admin credentials")
+}

--- a/internal/cmd/addRancher.go
+++ b/internal/cmd/addRancher.go
@@ -11,26 +11,26 @@ import (
 )
 
 var (
-	URL     string
-	Token   string
-	Cluster string
+	RancherURL     string
+	RancherToken   string
+	RancherCluster string
 )
 
 func init() {
-	addRancherCmd.Flags().StringVarP(&URL, "url", "u", "", "URL to a Rancher")
-	addRancherCmd.Flags().StringVarP(&Cluster, "cluster", "c", "", "URL to a Rancher")
-	addRancherCmd.Flags().StringVarP(&Token, "token", "t", "", "token to a Rancher")
+	addRancherCmd.Flags().StringVarP(&RancherURL, "url", "u", "", "URL to a Rancher")
+	addRancherCmd.Flags().StringVarP(&RancherCluster, "cluster", "c", "", "URL to a Rancher")
+	addRancherCmd.Flags().StringVarP(&RancherToken, "token", "t", "", "token to a Rancher")
 	addRancherCmd.MarkFlagRequired("url")
 	addRancherCmd.MarkFlagRequired("cluster")
 	addCmd.AddCommand(addRancherCmd)
 }
 
 func AddRancherComposer(cmd *cobra.Command, args []string) error {
-	URL, _ = cmd.Flags().GetString("url")
-	Token, _ = cmd.Flags().GetString("token")
-	Cluster, _ = cmd.Flags().GetString("cluter")
+	RancherURL, _ = cmd.Flags().GetString("url")
+	RancherToken, _ = cmd.Flags().GetString("token")
+	RancherCluster, _ = cmd.Flags().GetString("cluster")
 
-	err := AddRancher(URL, Cluster, Token)
+	err := AddRancher(RancherURL, RancherCluster, RancherToken)
 
 	return err
 }
@@ -41,7 +41,7 @@ func AddRancher(url string, cluster string, token string) error {
 	}
 	defaultCfg := kubeconfig.Load(kubeconfigPath)
 	logger = log.NewLogger(Verbose)
-	logger.Debug("downloading kubeconfig for a cluster", Cluster, "from", URL)
+	logger.Debug("downloading kubeconfig for a cluster", RancherCluster, "from", RancherURL)
 	rancherCfg, err := rancherClient.GetRancherConfig(url, cluster, token)
 	if err != nil {
 		fmt.Println(err)
@@ -56,9 +56,9 @@ func AddRancher(url string, cluster string, token string) error {
 }
 
 var addRancherCmd = &cobra.Command{
-	Use:   "rancher --url=[rancher url] --token=[rancher token]",
-	Short: "adding kubeconfig downloaded from a specific rancher installation",
-	Long:  "adding kubeconfig downloaded from a specific rancher installation",
+	Use:   "rancher --url=[rancher url] --token=[rancher token] --cluster=[cluster name]",
+	Short: "adds kubeconfig downloaded from a specific rancher installation",
+	Long:  "adds kubeconfig downloaded from a specific rancher installation",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return AddRancherComposer(cmd, args)
 	},


### PR DESCRIPTION
Added functionality which allows to download AKS config.

This subcommand requires additional Azure environment variables to be set:
* SUBSCRIPTION_ID - subscription ID where your cluster is located
* TENANT_ID - Azure tenant ID
* CLIENT_ID - client ID for service-principal
* CLIENT_SECRET secret for the service principal

How to use 
```bash
kcmanager add aks --url=[rancher url] --token=[rancher token] [flags]
```

Updated readme