### PR TITLE
Fix for kubeconfig export

### DIFF
--- a/internal/kubeconfig/construct.go
+++ b/internal/kubeconfig/construct.go
@@ -20,7 +20,7 @@ func Construct(ctx string, cfg *api.Config) (*api.Config, error) {
 		} else {
 			c.APIVersion = cfg.APIVersion
 			c.Kind = cfg.Kind
-			c.CurrentContext = cfg.CurrentContext
+			c.CurrentContext = ctx
 			c.Extensions = cfg.Extensions
 			c.Preferences = cfg.Preferences
 			c.Contexts[ctx] = ctd


### PR DESCRIPTION
Bug during the kubeconfig export. Exported config could have a current context set to non-existing, in the scope of the new kubeconfig, context.
Steps to reproduce:
- create a kubeconfig with a few contexts(e.g. ctx1 and ctx2)
- set current context to ctx2
- export ctx1
- the exported config has CurrentContext set to ctx2

This PR is setting the context to the name of a context you are exporting